### PR TITLE
Exclude .idea folder from project (.gitignore)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,9 @@ coverage.json
 #Hardhat files
 /solidity/cache
 
+#Jetbrains files
+.idea
+
 
 # INFO: https://stackoverflow.com/a/67198084/672346
 # ------- yarn -------


### PR DESCRIPTION
Folder is created by JetBrains IDEs to keep track of project settings, it's unnecessary for it to be on the remote.