### PR TITLE
[WIP] Added number of cosigns given to user profile

### DIFF
--- a/components/Forms/ProfileSettingsForm.tsx
+++ b/components/Forms/ProfileSettingsForm.tsx
@@ -22,7 +22,8 @@ export interface UserProfile {
   city: string;
   twitter: string;
   profilePic: string; // url
-  cosigns: number; // total number of cosigns that the user has earned on their submissions
+  cosignsReceived: number; // total number of cosigns that the user has earned on their submissions
+  cosignsGiven: number;// total number of cosigns that a user has given out
 }
 
 export const ProfileSettingsForm = ({ wallet }) => {

--- a/components/UserStatsBar.tsx
+++ b/components/UserStatsBar.tsx
@@ -4,7 +4,8 @@ import tw from "twin.macro";
 import { UserProfile } from "./Forms/ProfileSettingsForm";
 
 export const UserStatsBar: React.FC<{ profile: UserProfile }> = (props) => {
-  const { profilePic, username, city, cosignsReceived, cosignsGiven } = props.profile;
+  const { profilePic, username, city, cosignsReceived, cosignsGiven } =
+    props.profile;
 
   return (
     <UserStatsBarContainer>
@@ -30,15 +31,8 @@ export const UserStatsBar: React.FC<{ profile: UserProfile }> = (props) => {
           <Image src="/blue_diamond.png" alt="Cosigns received" layout="fill" />
         </div>
 
-        <p className="text-l italic">: {`${cosignsReceived}`}</p>
-      </div>
-      <div className="w-4" />
-      <div className="flex">
-        <div className="relative h-6 w-6">
-          <Image className="rotate-180" src="/blue_diamond.png" alt="Cosigns given" layout="fill" />
-        </div>
-
-        <p className="text-l italic">: {`${cosignsGiven}`}</p>
+        <p className="text-l italic">: {`${cosignsReceived}/`}</p>
+        <p className="text-l italic">{`${cosignsGiven}`}</p>
       </div>
     </UserStatsBarContainer>
   );

--- a/components/UserStatsBar.tsx
+++ b/components/UserStatsBar.tsx
@@ -4,7 +4,7 @@ import tw from "twin.macro";
 import { UserProfile } from "./Forms/ProfileSettingsForm";
 
 export const UserStatsBar: React.FC<{ profile: UserProfile }> = (props) => {
-  const { profilePic, username, city, cosigns } = props.profile;
+  const { profilePic, username, city, cosignsReceived, cosignsGiven } = props.profile;
 
   return (
     <UserStatsBarContainer>
@@ -27,10 +27,18 @@ export const UserStatsBar: React.FC<{ profile: UserProfile }> = (props) => {
       <div className="w-4" />
       <div className="flex">
         <div className="relative h-6 w-6">
-          <Image src="/blue_diamond.png" alt="cosigned" layout="fill" />
+          <Image src="/blue_diamond.png" alt="Cosigns received" layout="fill" />
         </div>
 
-        <p className="text-l italic">: {`${cosigns}`}</p>
+        <p className="text-l italic">: {`${cosignsReceived}`}</p>
+      </div>
+      <div className="w-4" />
+      <div className="flex">
+        <div className="relative h-6 w-6">
+          <Image className="rotate-180" src="/blue_diamond.png" alt="Cosigns given" layout="fill" />
+        </div>
+
+        <p className="text-l italic">: {`${cosignsGiven}`}</p>
       </div>
     </UserStatsBarContainer>
   );

--- a/utils/supabase.ts
+++ b/utils/supabase.ts
@@ -44,7 +44,7 @@ export const getProfileForWallet = async (wallet: string) => {
     //See: https://github.com/supabase/supabase/discussions/5737
     profileMeta.profilePic = `${profileMeta.profilePic}?cacheBust=${profileMeta.updateTime}`;
 
-  // get number of cosigns
+  // get number of cosigns received
 
   const submissionsQuery = await supabase
     .from("submissions")
@@ -54,14 +54,32 @@ export const getProfileForWallet = async (wallet: string) => {
   if (submissionsQuery.error) throw submissionsQuery.error;
 
   const submissions = submissionsQuery.data as Submission[];
-  const cosigns = submissions.reduce(
+  const cosignsReceived = submissions.reduce(
     (acc, curr) => acc + (curr?.cosigns?.length ?? 0),
     0
   );
 
+  // get number of cosigns given
+
+  const submissionsQueryAll = await supabase
+    .from("submissions")
+    .select()
+    .then(q=>q.body)
+
+  let cosignsGiven = 0;
+  submissionsQueryAll.forEach((submission) => {
+    let subCosigns = submission?.cosigns;
+    if (subCosigns) {
+      subCosigns.forEach((cosign) => {
+        if (cosign === wallet) cosignsGiven++;
+      });
+    }
+  });
+
   return {
     ...profileMeta,
-    cosigns,
+    cosignsReceived,
+    cosignsGiven,
   } as UserProfile;
 };
 

--- a/utils/supabase.ts
+++ b/utils/supabase.ts
@@ -61,13 +61,10 @@ export const getProfileForWallet = async (wallet: string) => {
 
   // get number of cosigns given
 
-  const submissionsQueryAll = await supabase
-    .from("submissions")
-    .select()
-    .then(q=>q.body)
+  const submissionsQueryAll = await supabase.from("submissions").select();
 
   let cosignsGiven = 0;
-  submissionsQueryAll.forEach((submission) => {
+  submissionsQueryAll.data.forEach((submission: Submission) => {
     let subCosigns = submission?.cosigns;
     if (subCosigns) {
       subCosigns.forEach((cosign) => {

--- a/utils/supabase.ts
+++ b/utils/supabase.ts
@@ -63,15 +63,10 @@ export const getProfileForWallet = async (wallet: string) => {
 
   const submissionsQueryAll = await supabase.from("submissions").select();
 
-  let cosignsGiven = 0;
-  submissionsQueryAll.data.forEach((submission: Submission) => {
-    let subCosigns = submission?.cosigns;
-    if (subCosigns) {
-      subCosigns.forEach((cosign) => {
-        if (cosign === wallet) cosignsGiven++;
-      });
-    }
-  });
+  const cosignsGiven = submissionsQueryAll.data
+    .flatMap((submission: Submission) => submission.cosigns)
+    .filter((c) => !!c)
+    .reduce((acc, c) => (c === wallet ? acc + 1 : acc), 0);
 
   return {
     ...profileMeta,


### PR DESCRIPTION
Here are a few things I wasnt sure about or things I believe I can improve on:
- I am not sure if I really had to do another request to supabase to get all submissions and be able to find out what of them the user cosigned.
- The operation to find how many submissions the user has cosigned can probably be written better
- The getProfileForWallet function seems to run for more users than the one logged in. Fetching information that may not be needed since the cosign numbers are seem to only used in the profile page. 
- I changed the original cosigns variable to cosignsReceived, I tried to rename it everywhere it was used, but I might have missed something
- I went experimental with the icon representations on the profile page, would like to get your feedback on that