### PR TITLE
Fix submissions errors

### DIFF
--- a/pages/submission/[id].tsx
+++ b/pages/submission/[id].tsx
@@ -148,6 +148,7 @@ export async function getStaticProps({ params }) {
   let submissionFileType = null;
   if (submission.mediaType === "File") {
     try {
+      if (typeof submission.mediaURI !== "string") throw "Submission mediaURI is undefined";
       const response = await fetch(submission.mediaURI, { method: "HEAD" });
       submissionFileType = response.headers.get("content-type");
     } catch (e) {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/19307482/182397370-58de2695-c60f-437a-8ca3-e6bc56d2d6c0.png)
Error: Cannot read properties of null (reading 'Symbol(Request internals)')

This happens when there is no mediaURI in the mediaType File submissions due to some error when uploading. Ideally, the submission of invalid files shouldn't happen tho.